### PR TITLE
update repository url for papermc so jitpack can build again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ version = project.plugin_version
 group = project.maven_group
 
 repositories {
-	maven { url = "https://papermc.io/repo/repository/maven-public/" }
+	maven { url = "https://repo.papermc.io/repository/maven-public/" }
 	mavenCentral()
 }
 


### PR DESCRIPTION
see https://jitpack.io/com/github/unilock/YepLib/2.3.0/build.log 
The old repository has been retired a while ago (?) 